### PR TITLE
Remove Play Store Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+This is the issue tracking repository for Boardwalk.
+
+(No code is stored here! Sorry!)
+
+To report an issue, please include the following information:
+
+- Version of Boardwalk
+- Your device model
+- Version of Android you're running
+- A description of the error
+- (Optionally) a screenshot of the error
+
+To create an issue, please click [Here](https://github.com/zhuowei/Boardwalk/issues/new).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 This is the issue tracking repository for Boardwalk.
 
+Download Boardwalk from Google Play: https://play.google.com/store/apps/details?id=net.zhuoweizhang.boardwalk
+
+Download APK for latest beta of Boardwalk: http://zhuoweizhang.net/Boardwalk/Boardwalk-release.apk
+
 (No code is stored here! Sorry!)
 
 To report an issue, please include the following information:

--- a/README.md
+++ b/README.md
@@ -14,4 +14,6 @@ To report an issue, please include the following information:
 - A description of the error
 - (Optionally) a screenshot of the error
 
+Please read the [FAQ](https://github.com/zhuowei/Boardwalk/wiki/FAQ) for some common errors and problems before creating issues.
+
 To create an issue, please click [Here](https://github.com/zhuowei/Boardwalk/issues/new?body=Version%20of%20Boardwalk%3A%0A%0AVersion%20of%20Android%3A%0A%0ADevice%20model%3A%0A%0ADescription%20of%20the%20problem%3A).

--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ To report an issue, please include the following information:
 - A description of the error
 - (Optionally) a screenshot of the error
 
-To create an issue, please click [Here](https://github.com/zhuowei/Boardwalk/issues/new).
+To create an issue, please click [Here](https://github.com/zhuowei/Boardwalk/issues/new?body=Version%20of%20Boardwalk%3A%0A%0AVersion%20of%20Android%3A%0A%0ADevice%20model%3A%0A%0ADescription%20of%20the%20problem%3A).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 This is the issue tracking repository for Boardwalk.
 
-Download Boardwalk from Google Play: https://play.google.com/store/apps/details?id=net.zhuoweizhang.boardwalk
+~~Download Boardwalk from Google Play: https://play.google.com/store/apps/details?id=net.zhuoweizhang.boardwalk~~
+Boardwalk has been taken down to fix an issue preventing it from running on Android Nougat and onwards. See https://github.com/zhuowei/Boardwalk/wiki/FAQ for more info.
 
 Download APK for latest beta of Boardwalk: http://zhuoweizhang.net/Boardwalk/Boardwalk-release.apk
 


### PR DESCRIPTION
As the Play Store link was taken down, I feel it's best we stop pointing people to it. We can add it back once the Nougat+ patch is out.